### PR TITLE
Fix UF2 conversion error by replacing elf2uf2-rs with picotool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gcc-arm-none-eabi dpkg-dev libudev1 libudev-dev
 
-        # Install elf2uf2-rs for UF2 conversion
-        cargo install elf2uf2-rs
+        # Install picotool for UF2 conversion (official Raspberry Pi tool)
+        sudo apt-get install -y cmake pkg-config libusb-1.0-0-dev
+        git clone https://github.com/raspberrypi/picotool.git
+        cd picotool
+        mkdir build && cd build
+        cmake ..
+        make -j$(nproc)
+        sudo make install
 
 
     - name: Build bootloader
@@ -79,8 +85,8 @@ jobs:
             base=$(basename "$elf" .elf)
             echo "Converting $base..."
 
-            # Convert to UF2 (for bootsel mode flashing)
-            elf2uf2-rs "$elf" "converted/${base}.uf2"
+            # Convert to UF2 (for bootsel mode flashing) using picotool
+            picotool uf2 convert "$elf" "converted/${base}.uf2"
 
             # Convert to BIN (for some programming tools)
             arm-none-eabi-objcopy -O binary "$elf" "converted/${base}.bin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
         # Copy original ELF files
         cp target/thumbv6m-none-eabi/release/bootloader artifacts/halpi2-rs-bootloader_${BOOTLOADER_VERSION}.elf
-        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware artifacts/halpi2-rs-firmware_${FIRMWARE_VERSION}.elf
+        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf artifacts/halpi2-rs-firmware_${FIRMWARE_VERSION}.elf
 
         # Convert each ELF to UF2 and BIN
         for elf in artifacts/*.elf; do

--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ rustup target add thumbv6m-none-eabi
 # Flashing and debugging
 cargo install probe-rs --features cli
 
-# UF2 conversion for bootsel mode
-cargo install elf2uf2-rs
+# UF2 conversion for bootsel mode (requires picotool)
+# On macOS: brew install picotool
+# On Ubuntu/Debian: build from source (see GitHub workflow for instructions)
 ```
 
 ### Build Commands

--- a/run
+++ b/run
@@ -15,6 +15,9 @@ function cargo-clean {
   # Clean the cargo build directory.
   # This is useful to remove all compiled artifacts and start fresh.
   cargo clean $@
+  # Remove any .elf copies that might be left behind
+  rm -f target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf
+  rm -f target/thumbv6m-none-eabi/debug/halpi2-rs-firmware.elf
 }
 
 function clean {
@@ -25,6 +28,13 @@ function clean {
 function build {
   # Build the project.
   cargo build $@
+  # Create .elf copy for tools that expect the extension
+  if [ -f target/thumbv6m-none-eabi/release/halpi2-rs-firmware ]; then
+    cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf
+  fi
+  if [ -f target/thumbv6m-none-eabi/debug/halpi2-rs-firmware ]; then
+    cp target/thumbv6m-none-eabi/debug/halpi2-rs-firmware target/thumbv6m-none-eabi/debug/halpi2-rs-firmware.elf
+  fi
 }
 
 function get-version {
@@ -47,7 +57,7 @@ function build-uf2 {
   # Get version from Cargo.toml
   VERSION=$(get-version)
   mkdir -p firmware/artifacts
-  elf2uf2-rs target/thumbv6m-none-eabi/release/halpi2-rs-firmware firmware/artifacts/halpi2-rs-firmware_${VERSION}.uf2
+  picotool uf2 convert target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf firmware/artifacts/halpi2-rs-firmware_${VERSION}.uf2
 }
 
 
@@ -66,7 +76,7 @@ function flash {
 }
 
 function monitor {
-  probe-rs attach --chip RP2040 target/thumbv6m-none-eabi/debug/halpi2-rs-firmware $@
+  probe-rs attach --chip RP2040 target/thumbv6m-none-eabi/debug/halpi2-rs-firmware.elf $@
 }
 
 function attach {
@@ -103,7 +113,7 @@ function copy-to-tester {
   VERSION=$(get-version)
   BOOTLOADER_VERSION=$(cargo pkgid -p bootloader | sed 's/.*#//')
   cp target/thumbv6m-none-eabi/release/bootloader ../HALPI2-tests/tests/200_controller/files/halpi2-rs-bootloader_${BOOTLOADER_VERSION}.elf
-  cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware ../HALPI2-tests/tests/200_controller/files/halpi2-rs-firmware_${VERSION}.elf
+  cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf ../HALPI2-tests/tests/200_controller/files/halpi2-rs-firmware_${VERSION}.elf
 }
 
 function build-debian {
@@ -134,7 +144,7 @@ function convert-artifacts {
 
   # Copy original ELF files
   cp target/thumbv6m-none-eabi/release/bootloader artifacts/halpi2-rs-bootloader_${BOOTLOADER_VERSION}.elf
-  cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware artifacts/halpi2-rs-firmware_${FIRMWARE_VERSION}.elf
+  cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.elf artifacts/halpi2-rs-firmware_${FIRMWARE_VERSION}.elf
 
   # Convert each ELF to UF2 and BIN
   for elf in artifacts/*.elf; do
@@ -142,8 +152,8 @@ function convert-artifacts {
       base=$(basename "$elf" .elf)
       echo "Converting $base..."
 
-      # Convert to UF2 (for bootsel mode flashing)
-      elf2uf2-rs "$elf" "artifacts/${base}.uf2"
+      # Convert to UF2 (for bootsel mode flashing) using picotool
+      picotool uf2 convert "$elf" "artifacts/${base}.uf2"
 
       # Convert to BIN (for some programming tools)
       cargo objcopy --release -- -O binary artifacts/halpi2-rs-firmware_${FIRMWARE_VERSION}.bin


### PR DESCRIPTION
## Summary
Fixes the "Unrecognized ABI" error in GitHub workflows by replacing elf2uf2-rs with the official Raspberry Pi picotool for UF2 conversion.

- Replace elf2uf2-rs with picotool in GitHub workflow and run script
- Update README.md with picotool installation instructions  
- Implement automatic .elf file creation for tool compatibility
- Clean up temporary file workarounds

## Changes Made
- **GitHub Workflow**: Install and use picotool instead of elf2uf2-rs
- **Run Script**: Update `build-uf2` and `convert-artifacts` functions to use picotool
- **Build Process**: Automatically create .elf copies after compilation for tool compatibility
- **Documentation**: Update README with picotool installation instructions
- **Cleanup**: Remove temporary file copying workarounds

## Problem Solved
The elf2uf2-rs tool was failing with "Unrecognized ABI" errors when converting ELF files built with newer Rust toolchains. This was preventing the GitHub "Build Firmware Draft" workflow from succeeding.

## Test Plan
- [x] Local testing: UF2 conversion works with picotool
- [x] Run script functions work: `./run build-uf2` and `./run convert-artifacts`
- [x] Build process automatically creates .elf files
- [x] All firmware binary references updated consistently

## Benefits
- Uses official Raspberry Pi tool (more reliable and maintained)
- Resolves compatibility issues with newer Rust toolchains
- Cleaner implementation without temporary file copying
- Consistent .elf naming across all tools

🤖 Generated with [Claude Code](https://claude.ai/code)