### PR TITLE
fix(debian): add lintian override for initial-upload-closes-no-bugs

### DIFF
--- a/debian/halpi2-firmware.lintian-overrides
+++ b/debian/halpi2-firmware.lintian-overrides
@@ -23,3 +23,6 @@ halpi2-firmware: arch-independent-package-contains-binary-or-object [usr/share/h
 
 # Package name contains "firmware" which suggests embedded section, not kernel
 halpi2-firmware: wrong-section-according-to-package-name embedded => kernel
+
+# Not an official Debian package, no ITP bug to close
+halpi2-firmware: initial-upload-closes-no-bugs


### PR DESCRIPTION
## Summary

Add lintian override for `initial-upload-closes-no-bugs` warning.

## Background

The `build-release.yml` shared workflow regenerates `debian/changelog` dynamically. The generated changelog doesn't include ITP (Intent To Package) bug references because this is not an official Debian archive package.

This warning started appearing after PR #33 was merged, causing the release build to fail.

## Test plan

- [ ] PR lintian check passes
- [ ] Release build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)