### PR TITLE
feat(packaging): include version in firmware filenames

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -76,14 +76,18 @@ runs:
 
     - name: Copy firmware to artifacts directory
       run: |
+        # Read versions
+        FW_VERSION=$(cat firmware/VERSION)
+        BL_VERSION=$(grep '^version' bootloader/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+
         mkdir -p artifacts
-        # Copy all firmware formats (UF2, BIN, ELF)
-        cp target/thumbv6m-none-eabi/release/bootloader.uf2 artifacts/
-        cp target/thumbv6m-none-eabi/release/bootloader.bin artifacts/
-        cp target/thumbv6m-none-eabi/release/bootloader artifacts/bootloader.elf
-        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.uf2 artifacts/
-        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.bin artifacts/
-        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware artifacts/halpi2-rs-firmware.elf
+        # Copy all firmware formats with version in filename
+        cp target/thumbv6m-none-eabi/release/bootloader.uf2 "artifacts/bootloader_${BL_VERSION}.uf2"
+        cp target/thumbv6m-none-eabi/release/bootloader.bin "artifacts/bootloader_${BL_VERSION}.bin"
+        cp target/thumbv6m-none-eabi/release/bootloader "artifacts/bootloader_${BL_VERSION}.elf"
+        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.uf2 "artifacts/halpi2-rs-firmware_${FW_VERSION}.uf2"
+        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware.bin "artifacts/halpi2-rs-firmware_${FW_VERSION}.bin"
+        cp target/thumbv6m-none-eabi/release/halpi2-rs-firmware "artifacts/halpi2-rs-firmware_${FW_VERSION}.elf"
         echo "Artifacts directory contents:"
         ls -la artifacts/
       shell: bash
@@ -112,22 +116,22 @@ runs:
         CONTENTS=$(dpkg-deb -c "$DEB_FILE")
         echo "$CONTENTS"
 
-        # Verify required firmware files are present
-        REQUIRED_FILES=(
-          "halpi2-rs-firmware.bin"
-          "halpi2-rs-firmware.elf"
-          "halpi2-rs-firmware.uf2"
-          "bootloader.bin"
-          "bootloader.elf"
-          "bootloader.uf2"
+        # Verify required firmware files are present (using patterns for versioned names)
+        REQUIRED_PATTERNS=(
+          "halpi2-rs-firmware_.*.bin"
+          "halpi2-rs-firmware_.*.elf"
+          "halpi2-rs-firmware_.*.uf2"
+          "bootloader_.*.bin"
+          "bootloader_.*.elf"
+          "bootloader_.*.uf2"
         )
 
         MISSING=0
-        for file in "${REQUIRED_FILES[@]}"; do
-          if echo "$CONTENTS" | grep -q "$file"; then
-            echo "✅ Found: $file"
+        for pattern in "${REQUIRED_PATTERNS[@]}"; do
+          if echo "$CONTENTS" | grep -qE "$pattern"; then
+            echo "✅ Found: $pattern"
           else
-            echo "❌ MISSING: $file"
+            echo "❌ MISSING: $pattern"
             MISSING=1
           fi
         done

--- a/debian/halpi2-firmware.lintian-overrides
+++ b/debian/halpi2-firmware.lintian-overrides
@@ -1,25 +1,26 @@
 # HALPI2 firmware files are RP2040 embedded binaries, not Linux executables.
 # These lintian warnings are expected and can be safely ignored.
+# Wildcards used to match versioned filenames (e.g., halpi2-rs-firmware_3.2.1.elf)
 
 # Embedded firmware ELF files are statically linked by design
-halpi2-firmware: statically-linked-binary [usr/share/halpi2-firmware/halpi2-rs-firmware.elf]
-halpi2-firmware: statically-linked-binary [usr/share/halpi2-firmware/bootloader.elf]
+halpi2-firmware: statically-linked-binary [usr/share/halpi2-firmware/halpi2-rs-firmware_*.elf]
+halpi2-firmware: statically-linked-binary [usr/share/halpi2-firmware/bootloader_*.elf]
 
 # Embedded firmware ELF files contain debug symbols for debugging/flashing
-halpi2-firmware: unstripped-binary-or-object [usr/share/halpi2-firmware/halpi2-rs-firmware.elf]
-halpi2-firmware: unstripped-binary-or-object [usr/share/halpi2-firmware/bootloader.elf]
+halpi2-firmware: unstripped-binary-or-object [usr/share/halpi2-firmware/halpi2-rs-firmware_*.elf]
+halpi2-firmware: unstripped-binary-or-object [usr/share/halpi2-firmware/bootloader_*.elf]
 
 # Raw binary firmware files are not ELF executables
-halpi2-firmware: executable-not-elf-or-script [usr/share/halpi2-firmware/halpi2-rs-firmware.bin]
-halpi2-firmware: executable-not-elf-or-script [usr/share/halpi2-firmware/bootloader.bin]
+halpi2-firmware: executable-not-elf-or-script [usr/share/halpi2-firmware/halpi2-rs-firmware_*.bin]
+halpi2-firmware: executable-not-elf-or-script [usr/share/halpi2-firmware/bootloader_*.bin]
 
 # Firmware ELF files in /usr/share are architecture-independent (RP2040 target, not host)
-halpi2-firmware: arch-dependent-file-in-usr-share [usr/share/halpi2-firmware/halpi2-rs-firmware.elf]
-halpi2-firmware: arch-dependent-file-in-usr-share [usr/share/halpi2-firmware/bootloader.elf]
+halpi2-firmware: arch-dependent-file-in-usr-share [usr/share/halpi2-firmware/halpi2-rs-firmware_*.elf]
+halpi2-firmware: arch-dependent-file-in-usr-share [usr/share/halpi2-firmware/bootloader_*.elf]
 
 # Architecture: all package intentionally contains RP2040 binaries (cross-compiled firmware)
-halpi2-firmware: arch-independent-package-contains-binary-or-object [usr/share/halpi2-firmware/halpi2-rs-firmware.elf]
-halpi2-firmware: arch-independent-package-contains-binary-or-object [usr/share/halpi2-firmware/bootloader.elf]
+halpi2-firmware: arch-independent-package-contains-binary-or-object [usr/share/halpi2-firmware/halpi2-rs-firmware_*.elf]
+halpi2-firmware: arch-independent-package-contains-binary-or-object [usr/share/halpi2-firmware/bootloader_*.elf]
 
 # Package name contains "firmware" which suggests embedded section, not kernel
 halpi2-firmware: wrong-section-according-to-package-name embedded => kernel


### PR DESCRIPTION
## Summary

Firmware files in the .deb package now include the version number in their filenames.

**Before:**
```
halpi2-rs-firmware.bin
halpi2-rs-firmware.elf
bootloader.bin
bootloader.elf
```

**After:**
```
halpi2-rs-firmware_3.2.1.bin
halpi2-rs-firmware_3.2.1.elf
bootloader_0.1.0.bin
bootloader_0.1.0.elf
```

## Why

This makes it easy to identify which firmware version is installed without querying the package manager. Previously, the version was only in the package name, not the actual files.

## Changes

- `.github/actions/build-deb/action.yml`: Read versions from `firmware/VERSION` and `bootloader/Cargo.toml`, include in artifact filenames
- `debian/halpi2-firmware.lintian-overrides`: Use wildcards (`*`) to match versioned filenames

## Test plan

- [x] Local Docker test passes with versioned filenames
- [x] Lintian passes with wildcard overrides
- [ ] PR checks pass
- [ ] Release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)